### PR TITLE
Check the script exists before including

### DIFF
--- a/src/Store.php
+++ b/src/Store.php
@@ -65,6 +65,20 @@ class Store extends TaggableStore implements StoreContract
     }
 
     /**
+     * Determines whether the key exists within the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
+    protected function exists($key)
+    {
+        if ($this->enabled && opcache_is_script_cached($this->filePath($key))) {
+            return true;
+        }
+        return file_exists($this->filePath($key));
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
@@ -72,7 +86,9 @@ class Store extends TaggableStore implements StoreContract
      */
     public function get($key)
     {
-        @include $this->filePath($key);
+        if ($this->exists($key)) {
+            @include $this->filePath($key);
+        }
 
         if (isset($exp) && $exp < time()) {
             /*
@@ -114,8 +130,7 @@ class Store extends TaggableStore implements StoreContract
      */
     public function add($key, $value, $minutes = 0)
     {
-        if ($this->enabled && opcache_is_script_cached($this->filePath($key))
-            || file_exists($this->filePath($key))) {
+        if ($this->exists($key)) {
             return false;
         }
         return $this->put($key, $value, $minutes);


### PR DESCRIPTION
On the back of [this](https://secure.php.net/manual/en/function.include.php#86527) (old but probably still relevant) comment I've added a check to see if the key exists before calling `include`.